### PR TITLE
Support extended signature for `message_type_support_callbacks_t::max_serialized_size()` from `rosidl_typesupport_fastrtps_cpp`

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -677,10 +677,17 @@ void RMW_Connext_MessageTypeSupport::type_info(
   /* The fastrtps type support sets full_bounded to false if unbounded,
      but assumes full_bounded == true by default */
   bool full_bounded = true;
-
+  
+#ifdef ROSIDL_TYPESUPPORT_FASTRTPS_HAS_PLAIN_TYPES
+  char bounds_info;
+  serialized_size_max =
+    static_cast<uint32_t>(callbacks->max_serialized_size(bounds_info));
+  full_bounded = 0 != (bounds_info & ROSIDL_TYPESUPPORT_FASTRTPS_BOUNDED_TYPE);
+#else
   serialized_size_max =
     static_cast<uint32_t>(callbacks->max_serialized_size(full_bounded));
-
+#endif
+  
   unbounded = !full_bounded;
 
   if (full_bounded && serialized_size_max == 0) {

--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -677,7 +677,7 @@ void RMW_Connext_MessageTypeSupport::type_info(
   /* The fastrtps type support sets full_bounded to false if unbounded,
      but assumes full_bounded == true by default */
   bool full_bounded = true;
-  
+
 #ifdef ROSIDL_TYPESUPPORT_FASTRTPS_HAS_PLAIN_TYPES
   char bounds_info;
   serialized_size_max =
@@ -687,7 +687,7 @@ void RMW_Connext_MessageTypeSupport::type_info(
   serialized_size_max =
     static_cast<uint32_t>(callbacks->max_serialized_size(full_bounded));
 #endif
-  
+
   unbounded = !full_bounded;
 
   if (full_bounded && serialized_size_max == 0) {


### PR DESCRIPTION
This PR adapts the code to the API break introduced by ros2/rosidl_typesupport_fastrtps#67