### PR TITLE
Change index.ros.org -> docs.ros.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROS 2 Middleware Layer for RTI Connext DDS
 
-This repository contains two novel implementations of the [ROS 2](https://index.ros.org/doc/ros2/)
+This repository contains two novel implementations of the [ROS 2](https://docs.ros.org/en/rolling)
 RMW layer which allow developers to deploy their ROS applications on top of
 [RTI Connext DDS Professional](https://www.rti.com/products/connext-dds-professional)
 and [RTI Connext DDS Micro](https://www.rti.com/products/connext-dds-micro).


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>