### PR TITLE
Allow sharing DomainParticipant with C++ applications

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
@@ -281,6 +281,14 @@
 #endif /* RMW_CONNEXT_FAST_ENDPOINT_DISCOVERY */
 
 /******************************************************************************
+ * Modify DomainParticipantQos to allow sharing of DDS entities created with
+ * the Connext C API with applications using the C++11 API.
+ ******************************************************************************/
+#ifndef RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP
+#define RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP     1
+#endif /* RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP */
+
+/******************************************************************************
  * Override dds.transport.UDPv4.builtin.ignore_loopback_interface in
  * DomainParticipantQos to force communication over loopback (in addition to
  * other transports, e.g. shared memory).

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -216,9 +216,9 @@ rmw_connextdds_initialize_participant_qos_impl(
   // to create new entities in C++11, even though the participant was created
   // using the C API. If these settings are not specified, an application will
   // receive a SIGSEGV when trying to create one of these entities.
-  dp_qos->user_object.flow_controller_user_object.size = sizeof(void*);
-  dp_qos->user_object.topic_user_object.size = sizeof(void*);
-  dp_qos->user_object.content_filtered_topic_user_object.size = sizeof(void*);
+  dp_qos->user_object.flow_controller_user_object.size = sizeof(void *);
+  dp_qos->user_object.topic_user_object.size = sizeof(void *);
+  dp_qos->user_object.content_filtered_topic_user_object.size = sizeof(void *);
 #endif /* RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP */
 
   return RMW_RET_OK;

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -207,6 +207,12 @@ rmw_connextdds_initialize_participant_qos_impl(
   }
 #endif /* RMW_CONNEXT_FAST_ENDPOINT_DISCOVERY */
 
+#if RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP
+  dp_qos->user_object.flow_controller_user_object.size = sizeof(void*);
+  dp_qos->user_object.topic_user_object.size = sizeof(void*);
+  dp_qos->user_object.content_filtered_topic_user_object.size = sizeof(void*);
+#endif /* RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP */
+
   return RMW_RET_OK;
 }
 

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -208,6 +208,14 @@ rmw_connextdds_initialize_participant_qos_impl(
 #endif /* RMW_CONNEXT_FAST_ENDPOINT_DISCOVERY */
 
 #if RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP
+  // UserObjectQosPolicy is an internal, undocumented Connext policy used by the
+  // implementations of different language bindings to control the memory
+  // representations of various objects created by user applications. In this
+  // case, the settings match the requirements of the "modern C++" API, and they
+  // allow the DomainParticipant to be used directly by applications that want
+  // to create new entities in C++11, even though the participant was created
+  // using the C API. If these settings are not specified, an application will
+  // receive a SIGSEGV when trying to create one of these entities.
   dp_qos->user_object.flow_controller_user_object.size = sizeof(void*);
   dp_qos->user_object.topic_user_object.size = sizeof(void*);
   dp_qos->user_object.content_filtered_topic_user_object.size = sizeof(void*);


### PR DESCRIPTION
This PR adjusts an internal Connext QoS policy to enable sharing of the DomainParticipant created by `rmw_connextdds` using the C API, with ROS 2 applications using the Modern C++ API.

With this changes, it is possible for the application to access the DomainParticipant and reuse it, e.g. to create endpoints, instead of creating a dedicated participant:

```cpp

#include <chrono>
#include <cstdio>
#include <memory>
#include <utility>

#include "rclcpp/rclcpp.hpp"

// Include RTI Connext DDS "modern C++" API
#include <dds/dds.hpp>
// Include type support code generated by rtiddsgen
#include "std_msgs/msg/String.hpp"

using namespace std::chrono_literals;
using namespace dds::core;

class DdsTalker : public rclcpp::Node
{
public:
  DdsTalker()
  : Node("dds_talker"),
    count_(0)
  {
    // Create a function to send messages periodically.
    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
    auto publish_message =
      [this]() -> void
      {
        std_msgs::msg::String msg("Hello World: " + std::to_string(count_++));
        RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", msg.data().c_str());
        writer_.write(msg);
      };
    // Create a DataWriter for topic "rt/chatter"
    auto participant = dds::domain::find(0);
    assert(dds::core::null != participant);
    dds::pub::Publisher publisher(participant);
    dds::topic::Topic<std_msgs::msg::String> topic(participant,
      "rt/chatter", "std_msgs::msg::dds_::String_");
    rti::core::policy::Property props;
    // Required to properly support unbounded types: size of the pre-allocated
    // sample memory pool. Sample's beyond this size will be dynamically allocated.
    props.set({"dds.data_writer.history.memory_manager.fast_pool.pool_buffer_max_size", "1024"}, false);
    auto writer_qos = publisher.default_datawriter_qos(); 
    writer_qos << props;
    writer_qos << policy::History(policy::HistoryKind::KEEP_LAST, 7);
    writer_ = dds::pub::DataWriter<std_msgs::msg::String>(publisher, topic, writer_qos);

    // Use a timer to schedule periodic message publishing.
    timer_ = this->create_wall_timer(1s, publish_message);
  }

private:
  size_t count_ = 1;
  dds::pub::DataWriter<std_msgs::msg::String> writer_{nullptr};
  rclcpp::TimerBase::SharedPtr timer_;
};

int main(int argc, char * argv[])
{
  rclcpp::init(argc, argv);
  rclcpp::spin(std::make_shared<DdsTalker>());
  rclcpp::shutdown();
  return 0;
}

```

The application must be linked with `-rdynamic` in order to share the DDS `DomainParticipantFactory` with `rmw_connextdds`. This can be achieved in cmake with:
```cmake
set_target_properties(executable PROPERTIES ENABLE_EXPORTS true)
```

It would be great to include this PR in Galactic, since it's such a trivial change and it enables access to some features which are not yet available in the RMW (e.g. zero copy).

The modified QoS Policy has no effect on the C core, and is only used by other language bindings built around it. I can run CI for this set of changes, but I don't expect any effect to "normal operations".
