### PR TITLE
Optimize QoS to improve responsiveness of reliable endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ its defaults.
 
 ### RMW_CONNEXT_DISABLE_RELIABILITY_OPTIMIZATIONS
 
-By default, `rmw_connextdds` will modify the QoS of each realiable DataWriter
+By default, `rmw_connextdds` will modify the QoS of each reliable DataWriter
 and DataReader to improve the responsiveness of the RTPS [reliability protocol](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Using_QosPolicies_to_Tune_the_Reliable_P.htm?tocpath=Part%203%3A%20Advanced%20Concepts%7C11.%20Reliable%20Communications%7C11.3%20Using%20QosPolicies%20to%20Tune%20the%20Reliable%20Protocol%7C_____0#reliable_1394042328_776265).
 
 For example, the ["heartbeat period"](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Controlling_Heartbeats_and_Retries.htm#reliable_1394042328_785637)

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ variables.
 - [RMW_CONNEXT_CYCLONE_COMPATIBILITY_MODE](#RMW_CONNEXT_CYCLONE_COMPATIBILITY_MODE)
 - [RMW_CONNEXT_DISABLE_LARGE_DATA_OPTIMIZATIONS](#RMW_CONNEXT_DISABLE_LARGE_DATA_OPTIMIZATIONS)
 - [RMW_CONNEXT_DISABLE_FAST_ENDPOINT_DISCOVERY](#RMW_CONNEXT_DISABLE_FAST_ENDPOINT_DISCOVERY)
+- [RMW_CONNEXT_DISABLE_RELIABILITY_OPTIMIZATIONS](#RMW_CONNEXT_DISABLE_RELIABILITY_OPTIMIZATIONS)
 - [RMW_CONNEXT_ENDPOINT_QOS_OVERRIDE_POLICY](#RMW_CONNEXT_ENDPOINT_QOS_OVERRIDE_POLICY)
 - [RMW_CONNEXT_INITIAL_PEERS](#RMW_CONNEXT_INITIAL_PEERS)
 - [RMW_CONNEXT_LEGACY_RMW_COMPATIBILITY_MODE](#RMW_CONNEXT_LEGACY_RMW_COMPATIBILITY_MODE)
@@ -206,6 +207,17 @@ for larger systems.
 Variable `RMW_CONNEXT_DISABLE_FAST_ENDPOINT_DISCOVERY` may be used to disable
 these automatic optimizations, and to leave the DomainParticipant's QoS to
 its defaults.
+
+### RMW_CONNEXT_DISABLE_RELIABILITY_OPTIMIZATIONS
+
+By default, `rmw_connextdds` will modify the QoS of each realiable DataWriter
+and DataReader to improve the responsiveness of the RTPS [reliability protocol](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Using_QosPolicies_to_Tune_the_Reliable_P.htm?tocpath=Part%203%3A%20Advanced%20Concepts%7C11.%20Reliable%20Communications%7C11.3%20Using%20QosPolicies%20to%20Tune%20the%20Reliable%20Protocol%7C_____0#reliable_1394042328_776265).
+
+For example, the ["heartbeat period"](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Controlling_Heartbeats_and_Retries.htm#reliable_1394042328_785637)
+is sped up from 3 seconds to 100 milliseconds.
+
+These optimizations may be disabled using variable
+`RMW_CONNEXT_DISABLE_RELIABILITY_OPTIMIZATIONS`.
 
 ### RMW_CONNEXT_ENDPOINT_QOS_OVERRIDE_POLICY
 

--- a/rmw_connextdds_common/include/rmw_connextdds/context.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/context.hpp
@@ -100,6 +100,9 @@ struct rmw_context_impl_s
 #if RMW_CONNEXT_DEFAULT_LARGE_DATA_OPTIMIZATIONS
   bool optimize_large_data{true};
 #endif /* RMW_CONNEXT_DEFAULT_LARGE_DATA_OPTIMIZATIONS */
+#if RMW_CONNEXT_DEFAULT_RELIABILITY_OPTIMIZATIONS
+  bool optimize_reliability{true};
+#endif /* RMW_CONNEXT_DEFAULT_RELIABILITY_OPTIMIZATIONS */
 
   enum class participant_qos_override_policy_t
   {

--- a/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
@@ -85,6 +85,11 @@
   "RMW_CONNEXT_DISABLE_LARGE_DATA_OPTIMIZATIONS"
 #endif /* RMW_CONNEXT_ENV_DISABLE_LARGE_DATA_OPTIMIZATIONS */
 
+#ifndef RMW_CONNEXT_ENV_DISABLE_RELIABILITY_OPTIMIZATIONS
+#define RMW_CONNEXT_ENV_DISABLE_RELIABILITY_OPTIMIZATIONS \
+  "RMW_CONNEXT_DISABLE_RELIABILITY_OPTIMIZATIONS"
+#endif /* RMW_CONNEXT_ENV_DISABLE_RELIABILITY_OPTIMIZATIONS */
+
 // TODO(security-wg): These are intended to be temporary, and need to be
 // refactored into a proper abstraction.
 #ifndef RMW_CONNEXT_ENV_SECURITY_LOG_FILE
@@ -225,6 +230,58 @@
 #ifndef RMW_CONNEXT_TYPE_OBJECT_MAX_SERIALIZED_SIZE
 #define RMW_CONNEXT_TYPE_OBJECT_MAX_SERIALIZED_SIZE   65000
 #endif /* RMW_CONNEXT_TYPE_OBJECT_MAX_SERIALIZED_SIZE */
+
+/******************************************************************************
+ * Customize the RTPS reliability protocol to speed up its responsiveness.
+ ******************************************************************************/
+#ifndef RMW_CONNEXT_DEFAULT_RELIABILITY_OPTIMIZATIONS
+#define RMW_CONNEXT_DEFAULT_RELIABILITY_OPTIMIZATIONS     1
+#endif /* RMW_CONNEXT_DEFAULT_RELIABILITY_OPTIMIZATIONS */
+
+/******************************************************************************
+ * Regular hearbeat period used by any reliable RTPS Writer.
+ * This is an initializer for an instance of type DDS_Duration_t.
+ ******************************************************************************/
+#ifndef RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD
+#define RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD       {0, 100000000}   /* 100ms */
+#endif /* RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD */
+
+/******************************************************************************
+ * Fast hearbeat period used by any reliable RTPS Writer to allow
+ * late joiners and out of sync readers to catch up.
+ * This is an initializer for an instance of type DDS_Duration_t.
+ ******************************************************************************/
+#ifndef RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD_FAST
+#define RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD_FAST  {0, 20000000}   /* 20ms */
+#endif /* RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD_FAST */
+
+/******************************************************************************
+ * When a DataWriter receives a request for missing DDS samples from a
+ * DataReader and responds by resending the requested DDS samples, it will
+ * ignore additional requests for the same DDS samples during the time period
+ * max_nack_response_delay. We decrease this to be less than the HB period.
+ ******************************************************************************/
+#ifndef RMW_CONNEXT_DEFAULT_MAX_NACK_RESPONSE_DELAY
+#define RMW_CONNEXT_DEFAULT_MAX_NACK_RESPONSE_DELAY  {0, 10000000}   /* 10ms */
+#endif /* RMW_CONNEXT_DEFAULT_MAX_NACK_RESPONSE_DELAY */
+
+/******************************************************************************
+ * Maximum number of periodic heartbeats gone unanswered after which a
+ * DataWriter will consider a DataReader as inactive.
+ *
+ ******************************************************************************/
+#ifndef RMW_CONNEXT_DEFAULT_MAX_HEARTBEATS
+#define RMW_CONNEXT_DEFAULT_MAX_HEARTBEATS    (10 * 60) /* 1m @ 10hz */
+#endif /* RMW_CONNEXT_DEFAULT_MAX_HEARTBEATS */
+
+/******************************************************************************
+ * When a reliable reader receives a heartbeat from a remote writer and finds
+ * out that it needs to send back an ACK/NACK message, the reader can choose to
+ * delay a while. We set this delay to be compatible with the HB period.
+ ******************************************************************************/
+#ifndef RMW_CONNEXT_DEFAULT_MAX_HEARTBEAT_RESPONSE_DELAY
+#define RMW_CONNEXT_DEFAULT_MAX_HEARTBEAT_RESPONSE_DELAY  {0, 10000000} /* 10ms */
+#endif /* RMW_CONNEXT_DEFAULT_MAX_HEARTBEAT_RESPONSE_DELAY */
 
 /******************************************************************************
  * Automatically tune DataWriterQos to better handle reliable "large data".

--- a/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
@@ -239,51 +239,6 @@
 #endif /* RMW_CONNEXT_DEFAULT_RELIABILITY_OPTIMIZATIONS */
 
 /******************************************************************************
- * Regular hearbeat period used by any reliable RTPS Writer.
- * This is an initializer for an instance of type DDS_Duration_t.
- ******************************************************************************/
-#ifndef RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD
-#define RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD       {0, 100000000}   /* 100ms */
-#endif /* RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD */
-
-/******************************************************************************
- * Fast hearbeat period used by any reliable RTPS Writer to allow
- * late joiners and out of sync readers to catch up.
- * This is an initializer for an instance of type DDS_Duration_t.
- ******************************************************************************/
-#ifndef RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD_FAST
-#define RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD_FAST  {0, 20000000}   /* 20ms */
-#endif /* RMW_CONNEXT_DEFAULT_HEARTBEAT_PERIOD_FAST */
-
-/******************************************************************************
- * When a DataWriter receives a request for missing DDS samples from a
- * DataReader and responds by resending the requested DDS samples, it will
- * ignore additional requests for the same DDS samples during the time period
- * max_nack_response_delay. We decrease this to be less than the HB period.
- ******************************************************************************/
-#ifndef RMW_CONNEXT_DEFAULT_MAX_NACK_RESPONSE_DELAY
-#define RMW_CONNEXT_DEFAULT_MAX_NACK_RESPONSE_DELAY  {0, 10000000}   /* 10ms */
-#endif /* RMW_CONNEXT_DEFAULT_MAX_NACK_RESPONSE_DELAY */
-
-/******************************************************************************
- * Maximum number of periodic heartbeats gone unanswered after which a
- * DataWriter will consider a DataReader as inactive.
- *
- ******************************************************************************/
-#ifndef RMW_CONNEXT_DEFAULT_MAX_HEARTBEATS
-#define RMW_CONNEXT_DEFAULT_MAX_HEARTBEATS    (10 * 60) /* 1m @ 10hz */
-#endif /* RMW_CONNEXT_DEFAULT_MAX_HEARTBEATS */
-
-/******************************************************************************
- * When a reliable reader receives a heartbeat from a remote writer and finds
- * out that it needs to send back an ACK/NACK message, the reader can choose to
- * delay a while. We set this delay to be compatible with the HB period.
- ******************************************************************************/
-#ifndef RMW_CONNEXT_DEFAULT_MAX_HEARTBEAT_RESPONSE_DELAY
-#define RMW_CONNEXT_DEFAULT_MAX_HEARTBEAT_RESPONSE_DELAY  {0, 10000000} /* 10ms */
-#endif /* RMW_CONNEXT_DEFAULT_MAX_HEARTBEAT_RESPONSE_DELAY */
-
-/******************************************************************************
  * Automatically tune DataWriterQos to better handle reliable "large data".
  ******************************************************************************/
 #ifndef RMW_CONNEXT_DEFAULT_LARGE_DATA_OPTIMIZATIONS

--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -1281,6 +1281,25 @@ rmw_api_connextdds_init(
     RMW_CONNEXT_LOG_DEBUG_A("initial DDS peers: %s", initial_peers)
   }
 
+#if RMW_CONNEXT_DEFAULT_RELIABILITY_OPTIMIZATIONS
+  // Check if we should disable the optimizations for the RTPS reliability protocol
+  const char * disable_optimize_reliability_env = nullptr;
+  lookup_rc = rcutils_get_env(
+    RMW_CONNEXT_ENV_DISABLE_RELIABILITY_OPTIMIZATIONS,
+    &disable_optimize_reliability_env);
+
+  if (nullptr != lookup_rc || nullptr == disable_optimize_reliability_env) {
+    RMW_CONNEXT_LOG_ERROR_A_SET(
+      "failed to lookup from environment: "
+      "var=%s, "
+      "rc=%s ",
+      RMW_CONNEXT_ENV_DISABLE_RELIABILITY_OPTIMIZATIONS,
+      lookup_rc)
+    return RMW_RET_ERROR;
+  }
+  ctx->optimize_reliability = '\0' == disable_optimize_reliability_env[0];
+#endif /* RMW_CONNEXT_DEFAULT_RELIABILITY_OPTIMIZATIONS */
+
   if (nullptr == RMW_Connext_gv_DomainParticipantFactory) {
     RMW_CONNEXT_ASSERT(1 == RMW_Connext_gv_ContextCount)
     RMW_CONNEXT_LOG_DEBUG("initializing DDS DomainParticipantFactory")


### PR DESCRIPTION
This PR introduces some "on by default" QoS optimizations  for the RTPS [reliability protocol](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Using_QosPolicies_to_Tune_the_Reliable_P.htm?tocpath=Part%203%3A%20Advanced%20Concepts%7C11.%20Reliable%20Communications%7C11.3%20Using%20QosPolicies%20to%20Tune%20the%20Reliable%20Protocol%7C_____0#reliable_1394042328_776265) parameters used by reliable DataWriters and DataReaders.

By default, Connext uses a pretty slow ["heartbeat period"](https://community.rti.com/static/documentation/connext-dds/6.0.1/doc/manuals/connext_dds/html_files/RTI_ConnextDDS_CoreLibraries_UsersManual/Content/UsersManual/Controlling_Heartbeats_and_Retries.htm#reliable_1394042328_785637) of 3 seconds. This configuration makes the reliability protocol pretty slow to react to missed samples.

With these changes, `rmw_connextdds` will reduce the heartbeat period to 100ms, with a minimum of 20ms. This should be in line with the default settings of other DDS vendors.

The optimizations can be disabled with variable `RMW_CONNEXT_DISABLE_RELIABILITY_OPTIMIZATIONS`, for example if a user would prefer to customize these parameters via XML (which is ultimately always the best solution for a complex system).
