### PR TITLE
Use rmw_qos_profile_unknown when adding entity to graph

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_graph.cpp
+++ b/rmw_connextdds_common/src/common/rmw_graph.cpp
@@ -740,7 +740,7 @@ rmw_connextdds_graph_add_entityEA(
   rmw_connextdds_guid_to_gid(*endp_guid, gid);
   rmw_connextdds_guid_to_gid(*dp_guid, dp_gid);
 
-  rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_unknown;
 
   if (RMW_RET_OK !=
     rmw_connextdds_readerwriter_qos_to_ros(


### PR DESCRIPTION
Some of the qos policies aren't shared during discovery (history).
Use `rmw_qos_profile_unknown` as the base profile, so users of `rmw_get_publishers_info_by_topic()`, `rmw_get_subscriptions_info_by_topic()` can tell which policy was correctly filled by the middleware and which not.

This was already the case in [fastrtps](https://github.com/ros2/rmw_fastrtps/blob/7bb3563bebd20c3cae03231c2e321bf132651449/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_participant_info.hpp#L149).
Cyclonedds is also sharing `history` during discovery, so this is not an issue.

We're also documenting this in https://github.com/ros2/rmw/pull/308, because docs weren't clear in the past.