### PR TITLE
Correctly detect empty messages

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -683,7 +683,7 @@ void RMW_Connext_MessageTypeSupport::type_info(
 
   unbounded = !full_bounded;
 
-  if (unbounded && serialized_size_max == 0) {
+  if (full_bounded && serialized_size_max == 0) {
     /* Empty message */
     empty = true;
     serialized_size_max = 1;


### PR DESCRIPTION
This PR fixes a bug in `RMW_Connext_MessageTypeSupport::type_info()` which prevents correct detection of empty messages when querying the `fastrtps` type support.

No test is currently failing because of this (AFAIK), but it seems a critical fix to properly support empty messages.

This bug was spotted by @MiguelCompany and it is already fixed in #14, but since that PR might be delayed to H-turtle, we should probably commit the fix separately.