### PR TITLE
Backport #25 to branch `eloquent`

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/static_config.hpp
@@ -281,6 +281,14 @@
 #endif /* RMW_CONNEXT_FAST_ENDPOINT_DISCOVERY */
 
 /******************************************************************************
+ * Modify DomainParticipantQos to allow sharing of DDS entities created with
+ * the Connext C API with applications using the C++11 API.
+ ******************************************************************************/
+#ifndef RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP
+#define RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP     1
+#endif /* RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP */
+
+/******************************************************************************
  * Override dds.transport.UDPv4.builtin.ignore_loopback_interface in
  * DomainParticipantQos to force communication over loopback (in addition to
  * other transports, e.g. shared memory).

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -169,6 +169,20 @@ rmw_connextdds_initialize_participant_qos_impl(
   }
 #endif /* RMW_CONNEXT_FAST_ENDPOINT_DISCOVERY */
 
+#if RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP
+  // UserObjectQosPolicy is an internal, undocumented Connext policy used by the
+  // implementations of different language bindings to control the memory
+  // representations of various objects created by user applications. In this
+  // case, the settings match the requirements of the "modern C++" API, and they
+  // allow the DomainParticipant to be used directly by applications that want
+  // to create new entities in C++11, even though the participant was created
+  // using the C API. If these settings are not specified, an application will
+  // receive a SIGSEGV when trying to create one of these entities.
+  dp_qos->user_object.flow_controller_user_object.size = sizeof(void *);
+  dp_qos->user_object.topic_user_object.size = sizeof(void *);
+  dp_qos->user_object.content_filtered_topic_user_object.size = sizeof(void *);
+#endif /* RMW_CONNEXT_SHARE_DDS_ENTITIES_WITH_CPP */
+
   return RMW_RET_OK;
 }
 


### PR DESCRIPTION
This PR backports changes from PR #25 to branch `eloquent`.

I have verified locally that the code builds and that things work with a hello world. I'm creating the PR only for bookkeeping purposes.
I will merge it without additional reviews, since Eloquent is not supported as Tier 1.