### PR TITLE
Backport #23 and #33 to branch `eloquent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROS 2 Middleware Layer for RTI Connext DDS
 
-This repository contains two novel implementations of the [ROS 2](https://index.ros.org/doc/ros2/)
+This repository contains two novel implementations of the [ROS 2](https://docs.ros.org/en/rolling)
 RMW layer which allow developers to deploy their ROS applications on top of
 [RTI Connext DDS Professional](https://www.rti.com/products/connext-dds-professional)
 and [RTI Connext DDS Micro](https://www.rti.com/products/connext-dds-micro).

--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -683,7 +683,7 @@ void RMW_Connext_MessageTypeSupport::type_info(
 
   unbounded = !full_bounded;
 
-  if (unbounded && serialized_size_max == 0) {
+  if (full_bounded && serialized_size_max == 0) {
     /* Empty message */
     empty = true;
     serialized_size_max = 1;


### PR DESCRIPTION
This PR backports changes from PRs #23 and #33 to branch `eloquent`.

I have verified locally that the code builds and that things work with a hello world. I'm creating the PR only for bookkeeping purposes.
I will merge it without additional reviews, since Eloquent is not supported as Tier 1.