### PR TITLE
Improved conversion of time values between ROS and DDS formats

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -423,14 +423,18 @@ rmw_connextdds_get_readerwriter_qos(
       }
   }
 
-  if (!rmw_time_equal(qos_policies->lifespan, RMW_DURATION_UNSPECIFIED)) {
+  // LifespanQosPolicy is a writer-only policy, so `lifespan` might be NULL.
+  // Micro does not support this policy, so the value will always be NULL.
+#if RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_MICRO
+  assert(nullptr == lifespan);
+#endif /* RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_MICRO */
+  if (lifespan != nullptr &&
+    !rmw_time_equal(qos_policies->lifespan, RMW_DURATION_UNSPECIFIED))
+  {
+    // Guard access to type since it's not defined by Micro (only forward declared
+    // by rmw_connextdds/dds_api_rtime.hpp)
 #if RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_PRO
-    assert(nullptr != lifespan);
     lifespan->duration = rmw_time_to_dds_duration(qos_policies->lifespan);
-#else
-    // Print a warning when lifespan is not supported but was customized by user.
-    assert(nullptr == lifespan);
-    RMW_CONNEXT_LOG_WARNING("lifespan qos policy not supported")
 #endif /* RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_PRO */
   }
 

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -427,16 +427,15 @@ rmw_connextdds_get_readerwriter_qos(
   // Micro does not support this policy, so the value will always be NULL.
 #if RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_MICRO
   assert(nullptr == lifespan);
-#endif /* RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_MICRO */
+#else /* RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_PRO */
   if (lifespan != nullptr &&
     !rmw_time_equal(qos_policies->lifespan, RMW_DURATION_UNSPECIFIED))
   {
     // Guard access to type since it's not defined by Micro (only forward declared
     // by rmw_connextdds/dds_api_rtime.hpp)
-#if RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_PRO
     lifespan->duration = rmw_time_to_dds_duration(qos_policies->lifespan);
-#endif /* RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_PRO */
   }
+#endif /* RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_PRO */
 
   return RMW_RET_OK;
 }


### PR DESCRIPTION
This PR applies changes similar to ros2/rmw_connext#491 to properly handle value `RMW_DURATION_INFINITE` and `RMW_DURATION_UNSPECIFIED` when converting time values between ROS and DDS formats.

The conversion to ROS format uses helper function `rmw_dds_common::clamp_rmw_time_to_dds_time()` to make sure that the ROS time can be represented by DDS (note that the current implementation does not actually guarantee it, but it will after ros2/rmw_dds_common#48 is merged).

I also took the chance to delete some commented out code, and made a small change to make sure users are informed with a warning that they are trying to configure lifespan qos on an RMW that doesn't support it (i.e. `rmw_connextddsmicro`).

The need to open this PR for the `galactic` branch comes from ros2/rosbag2#756 and the fact that `ros2 bag play` is currently broken with `rmw_connextdds` in Galactic/Rolling.

I will open another PR afterwards to merge this feature to `master`.