### PR TITLE
Update rti-connext-dds dependency to 6.0.1.

### DIFF
--- a/rti_connext_dds_cmake_module/package.xml
+++ b/rti_connext_dds_cmake_module/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
 
-  <depend>rti-connext-dds-5.3.1</depend>
+  <depend>rti-connext-dds-6.0.1</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Now that this package is available in the ROS bootstrap repository for
Ubuntu Focal and Jammy we can bump the expected dependency version.

Requires https://github.com/ros2/ci/pull/614 and https://github.com/ros/rosdistro/pull/32045