### PR TITLE
Update launch_testing_ros output filter prefixes for Connext6

### DIFF
--- a/rmw_connextdds/CMakeLists.txt
+++ b/rmw_connextdds/CMakeLists.txt
@@ -73,4 +73,4 @@ ament_package(
 )
 
 ament_index_register_resource("rmw_output_prefixes"
-  CONTENT "RTI Data Distribution Service\nExpires on")
+  CONTENT "RTI Data Distribution Service\nRTI Connext DDS\nExpires on")


### PR DESCRIPTION
Hopefully, fixes https://github.com/ros2/ros2cli/issues/705.