### PR TITLE
Resolve build error with RTI Connext DDS 5.3.1

### DIFF
--- a/rmw_connextdds_common/src/ndds/custom_sql_filter.cpp
+++ b/rmw_connextdds_common/src/ndds/custom_sql_filter.cpp
@@ -541,7 +541,7 @@ RTI_CustomSqlFilter_writer_evaluate(
       reinterpret_cast<char *>(
         const_cast<uint8_t *>(serialized_sample)),
       serialized_size);
-    if (!RTICdrStream_deserializeCdrEncapsulationAndSetDefault(&cdr_stream)) {
+    if (!RTICdrStream_deserializeCdrEncapsulationAndSetDefault((&cdr_stream))) {
       RMW_CONNEXT_LOG_ERROR("failed to deserialize and set CDR encapsulation")
       return nullptr;
     }
@@ -714,7 +714,7 @@ RTI_CustomSqlFilter_evaluate(
     &cdr_stream,
     reinterpret_cast<char *>(msg->data_buffer.buffer),
     msg->data_buffer.buffer_length);
-  if (!RTICdrStream_deserializeCdrEncapsulationAndSetDefault(&cdr_stream)) {
+  if (!RTICdrStream_deserializeCdrEncapsulationAndSetDefault((&cdr_stream))) {
     RMW_CONNEXT_LOG_ERROR("failed to deserialize and set CDR encapsulation")
     return DDS_BOOLEAN_FALSE;
   }


### PR DESCRIPTION
This PR resolves a [compilation error when building `rmw_connextdds` with RTI Connext DDS 5.3.1](https://github.com/ros2/rmw_connextdds/pull/81#issuecomment-1097419848) that was introduced by #81.