### PR TITLE
Switch ROS2 -> ROS 2 everywhere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ consider uninstalling `rmw_connext_cpp` and `connext_cmake_module`
 
 ## Runtime Configuration
 
-In addition to standard configuration facilities provided by the ROS2 RMW
+In addition to standard configuration facilities provided by the ROS 2 RMW
 interface, `rmw_connextdds`, and `rmw_connextddsmicro` support the additional
 configuration of some aspects of their runtime behavior via custom environment
 variables.
@@ -162,9 +162,9 @@ variables.
 
 Enable different policies to improve interoperability with `rmw_cyclonedds_cpp`.
 
-By default, ROS2 applications using `rmw_connextdds` will be able to communicate
-with those using `rmw_cyclonedds_cpp` only via ROS2 publishers and subscribers,
-while ROS2 clients and services will not interoperate across vendors.
+By default, ROS 2 applications using `rmw_connextdds` will be able to communicate
+with those using `rmw_cyclonedds_cpp` only via ROS 2 publishers and subscribers,
+while ROS 2 clients and services will not interoperate across vendors.
 
 The reason for this incompatibility lies in `rmw_cyclonedds_cpp`'s use of a custom
 mapping for propagating request metadata between clients and services.
@@ -268,13 +268,13 @@ RMW_CONNEXT_INITIAL_PEERS="_shmem://, 239.255.0.1" \
 
 ### RMW_CONNEXT_LEGACY_RMW_COMPATIBILITY_MODE
 
-ROS2 applications using `rmw_connextdds` will not be able to interoperate with
+ROS 2 applications using `rmw_connextdds` will not be able to interoperate with
 applications using the previous RMW implementation for RTI Connext DDS, `rmw_connext_cpp`,
 unless variable `RMW_CONNEXT_LEGACY_RMW_COMPATIBILITY_MODE` is used to enable
 a "compatibility" mode with these older implementation.
 
 In particular, when this mode is enabled, `rmw_connextdds` will revert to adding
-a suffix (`_`) to the end of the names of the attributes of the ROS2 data types
+a suffix (`_`) to the end of the names of the attributes of the ROS 2 data types
 propagated via DDS discovery.
 
 ### RMW_CONNEXT_PARTICIPANT_QOS_OVERRIDE_POLICY
@@ -301,7 +301,7 @@ optimizations controlled by [RMW_CONNEXT_DISABLE_FAST_ENDPOINT_DISCOVERY](#RMW_C
 
 The [DDS-RPC specification](https://www.omg.org/spec/DDS-RPC/About-DDS-RPC/)
 defines two profiles for mapping "request/reply" interactions over DDS messages
-(e.g. ROS2 clients and services):
+(e.g. ROS 2 clients and services):
 
 - the *basic* profile conveys information about the originator of a request as
   an inline payload, serialized before the actual request/reply payloads.
@@ -310,7 +310,7 @@ defines two profiles for mapping "request/reply" interactions over DDS messages
   information out of band.
 
 By default, `rmw_connextdds` uses the *extended* profile when sending requests
-from a ROS2 client to a service, while `rmw_connextddsmicro` uses the *basic* one.
+from a ROS 2 client to a service, while `rmw_connextddsmicro` uses the *basic* one.
 
 Variable `RMW_CONNEXT_REQUEST_REPLY_MAPPING` can be used to select the actual
 profile used at runtime. Either `"basic"` or `"extended"` may be specified.

--- a/rmw_connextdds/package.xml
+++ b/rmw_connextdds/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>rmw_connextdds</name>
   <version>0.11.1</version>
-  <description>A ROS2 RMW implementation built with RTI Connext DDS Professional.</description>
+  <description>A ROS 2 RMW implementation built with RTI Connext DDS Professional.</description>
   <maintainer email="asorbini@rti.com">Andrea Sorbini</maintainer>
   <license>Apache License 2.0</license>
 

--- a/rmw_connextddsmicro/package.xml
+++ b/rmw_connextddsmicro/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>rmw_connextddsmicro</name>
   <version>0.11.1</version>
-  <description>A ROS2 RMW implementation built with RTI Connext DDS Micro.</description>
+  <description>A ROS 2 RMW implementation built with RTI Connext DDS Micro.</description>
   <maintainer email="asorbini@rti.com">Andrea Sorbini</maintainer>
   <license>Apache License 2.0</license>
 


### PR DESCRIPTION
We prefer the space.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>