### PR TITLE
Fix assert in dds_duration_to_rmw_time

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -286,7 +286,7 @@ dds_duration_to_rmw_time(const DDS_Duration_t & duration)
   if (DDS_Duration_is_infinite(&duration)) {
     return RMW_DURATION_INFINITE;
   }
-  assert(duration.sec > 0);
+  assert(duration.sec >= 0);
   rmw_time_t result = {static_cast<uint64_t>(duration.sec), duration.nanosec};
   return result;
 }


### PR DESCRIPTION
Allow the seconds field of a DDS_Duration_t to be zero.

Currently, when running the Debug build of the test, test_best_available__rmw_connext_dds, the following assertion failure results:
```
test_best_available__rmw_connextdds: /home/michael/src/ros2/src/ros2/rmw_connextdds/rmw_connextdds_common/src/common/rmw_impl.cpp:289: rmw_time_t dds_duration_to_rmw_time(const DDS_Duration_t&): Assertion `duration.sec > 0' failed.
Aborted (core dumped)
```

This is because the assertion is checking that the (signed) seconds field is greater than zero. However, the test itself, sets the duration for the publisher_deadline to 2 milliseconds:

```
TEST_F(QosRclcppTestFixture, test_best_available_policies_subscription) {
  const std::string topic = "/test_best_available_subscription";
  const std::chrono::milliseconds publish_period{5000};
  const std::chrono::milliseconds publisher_deadline{2};
  const std::chrono::milliseconds publisher_liveliness_lease_duration{3};
```

which results in a duration with 0 seconds, causing the failure. 

I believe the intention was to check that the seconds field is >= 0. 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>