### PR TITLE
Add stub dynamic network interface implementation.

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
@@ -67,6 +67,14 @@ bool rmw_connextdds_find_string_in_list(
 DDS_Duration_t rmw_connextdds_duration_from_ros_time(
   const rmw_time_t * const ros_time);
 
+/**
+ * This function returns `NULL` when either the node handle is `NULL` or when the
+ * node handle is from a different rmw implementation.
+ *
+ * \return rmw_ret_t non `NULL` value if successful, otherwise `NULL`
+ */
+rmw_ret_t rmw_notify_participant_dynamic_network_interface(rmw_context_t * context);
+
 /******************************************************************************
  * WaitSet wrapper
  ******************************************************************************/

--- a/rmw_connextdds_common/src/common/rmw_node.cpp
+++ b/rmw_connextdds_common/src/common/rmw_node.cpp
@@ -229,3 +229,9 @@ rmw_api_connextdds_node_get_graph_guard_condition(const rmw_node_t * rmw_node)
 
   return node_impl->graph_guard_condition();
 }
+
+rmw_ret_t
+rmw_notify_participant_dynamic_network_interface(rmw_context_t * context)
+{
+  return RMW_RET_INCORRECT_RMW_IMPLEMENTATION;
+}


### PR DESCRIPTION
Per this https://github.com/ros2/rclcpp/pull/2086#issuecomment-1397608661 comment on a related PR, this PR seeks to add a stubbed version of a feature developed for rmw_fastrtps: https://github.com/ros2/rmw_fastrtps/pull/662 so that if this feature is called with an rmw layer that does not implement the feature, it returns an error that can be handled.

Signed-off-by: Sebastian Jakymiw <sjakymiw@irobot.com>

