### PR TITLE
Use unified approach for checking the existence of environment variables

### DIFF
--- a/rti_connext_dds_cmake_module/cmake/rti_build_helper.cmake
+++ b/rti_connext_dds_cmake_module/cmake/rti_build_helper.cmake
@@ -405,7 +405,7 @@ endfunction()
 # (e.g. ".DS_Store").
 ################################################################################
 function(rti_guess_connextdds_arch)
-  if(ENV{CONNEXTDDS_ARCH})
+  if(NOT "$ENV{CONNEXTDDS_ARCH}" STREQUAL "")
     set(CONNEXTDDS_ARCH $ENV{CONNEXTDDS_ARCH} PARENT_SCOPE)
     return()
   endif()


### PR DESCRIPTION
In rti_build_helper.cmake the most the prevalent mechanism for checking whether an environment variable has been set is reading it and comparing the result with the empty string. 

The check for CONNEXTDDS_ARCH didn't use that mechanism though. However, the mechanism there doesn't work with newer cmake versions (trested it with 3.22.1). With this fix, CONNEXTDDS_ARCH will be detected in older and newer cmake versions.