### PR TITLE
Warns if new DDS OOBE settings are used with Connext 

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -753,6 +753,20 @@ rmw_api_connextdds_init(
     return RMW_RET_INVALID_ARGUMENT;
   }
 
+  if (context->options.discovery_params.static_peers_count > 0)
+  {
+    RMW_CONNEXT_LOG_WARNING("Static peers settings are currently not "
+     "implmented for rmw connext. The settings you have will be ignored.");
+  }
+
+  if (context->options.discovery_params->automatic_discovery_range
+    != RMW_AUTOMATIC_DISCOVERY_RANGE_SUBNET)
+  {
+    RMW_CONNEXT_LOG_WARNING("Discovery range settings are currently not "
+     "implmented for rmw connext. The settings you have will be ignored. "
+     "CONNEXT will default to SUBNET behaviour.");
+  }
+
   if (options->domain_id >= INT32_MAX &&
     options->domain_id != RMW_DEFAULT_DOMAIN_ID)
   {

--- a/rmw_connextdds_common/src/common/rmw_discovery.cpp
+++ b/rmw_connextdds_common/src/common/rmw_discovery.cpp
@@ -56,6 +56,7 @@ rmw_connextdds_discovery_thread(rmw_context_impl_t * ctx)
 
   RMW_Connext_Subscriber * const sub_partinfo =
     reinterpret_cast<RMW_Connext_Subscriber *>(ctx->common.sub->data);
+
   DDS_ConditionSeq active_conditions = DDS_SEQUENCE_INITIALIZER;
   DDS_ReturnCode_t rc = DDS_RETCODE_ERROR;
   DDS_UnsignedLong active_len = 0,

--- a/rmw_connextdds_common/src/common/rmw_discovery.cpp
+++ b/rmw_connextdds_common/src/common/rmw_discovery.cpp
@@ -56,7 +56,7 @@ rmw_connextdds_discovery_thread(rmw_context_impl_t * ctx)
 
   RMW_Connext_Subscriber * const sub_partinfo =
     reinterpret_cast<RMW_Connext_Subscriber *>(ctx->common.sub->data);
-
+  
   DDS_ConditionSeq active_conditions = DDS_SEQUENCE_INITIALIZER;
   DDS_ReturnCode_t rc = DDS_RETCODE_ERROR;
   DDS_UnsignedLong active_len = 0,

--- a/rmw_connextdds_common/src/common/rmw_discovery.cpp
+++ b/rmw_connextdds_common/src/common/rmw_discovery.cpp
@@ -56,7 +56,6 @@ rmw_connextdds_discovery_thread(rmw_context_impl_t * ctx)
 
   RMW_Connext_Subscriber * const sub_partinfo =
     reinterpret_cast<RMW_Connext_Subscriber *>(ctx->common.sub->data);
-  
   DDS_ConditionSeq active_conditions = DDS_SEQUENCE_INITIALIZER;
   DDS_ReturnCode_t rc = DDS_RETCODE_ERROR;
   DDS_UnsignedLong active_len = 0,


### PR DESCRIPTION
This PR warns if new OOBE settings are used with CONNEXT (see: https://discourse.ros.org/t/proposed-changes-to-how-ros-performs-discovery-of-nodes/27640/23).

Note: 
Depends on: 
  https://github.com/ros2/rmw/pull/338