### PR TITLE
Runtime Interface Reflection: rmw_connextdds stubs for new RMW interfaces

### DIFF
--- a/rmw_connextdds/src/rmw_api_impl_ndds.cpp
+++ b/rmw_connextdds/src/rmw_api_impl_ndds.cpp
@@ -981,3 +981,52 @@ rmw_feature_supported(rmw_feature_t feature)
       }
   }
 }
+
+/******************************************************************************
+ * Dynamic message typesupport
+ ******************************************************************************/
+rmw_ret_t
+rmw_take_dynamic_message(
+  const rmw_subscription_t * subscription,
+  rosidl_dynamic_typesupport_dynamic_data_t * dynamic_message,
+  bool * taken,
+  rmw_subscription_allocation_t * allocation)
+{
+  static_cast<void>(subscription);
+  static_cast<void>(dynamic_message);
+  static_cast<void>(taken);
+  static_cast<void>(allocation);
+
+  RMW_SET_ERROR_MSG("rmw_take_dynamic_message: unimplemented");
+  return RMW_RET_UNSUPPORTED;
+}
+
+rmw_ret_t
+rmw_take_dynamic_message_with_info(
+  const rmw_subscription_t * subscription,
+  rosidl_dynamic_typesupport_dynamic_data_t * dynamic_message,
+  bool * taken,
+  rmw_message_info_t * message_info,
+  rmw_subscription_allocation_t * allocation)
+{
+  static_cast<void>(subscription);
+  static_cast<void>(dynamic_message);
+  static_cast<void>(taken);
+  static_cast<void>(message_info);
+  static_cast<void>(allocation);
+
+  RMW_SET_ERROR_MSG("rmw_take_dynamic_message_with_info: unimplemented");
+  return RMW_RET_UNSUPPORTED;
+}
+
+rmw_ret_t
+rmw_get_serialization_support(
+  const char * serialization_lib_name,
+  rosidl_dynamic_typesupport_serialization_support_t ** serialization_support)
+{
+  static_cast<void>(serialization_lib_name);
+  static_cast<void>(serialization_support);
+
+  RMW_SET_ERROR_MSG("rmw_get_serialization_support: unimplemented");
+  return RMW_RET_UNSUPPORTED;
+}

--- a/rmw_connextddsmicro/src/rmw_api_impl_rtime.cpp
+++ b/rmw_connextddsmicro/src/rmw_api_impl_rtime.cpp
@@ -985,3 +985,52 @@ rmw_feature_supported(rmw_feature_t feature)
       }
   }
 }
+
+/******************************************************************************
+ * Dynamic message typesupport
+ ******************************************************************************/
+rmw_ret_t
+rmw_take_dynamic_message(
+  const rmw_subscription_t * subscription,
+  rosidl_dynamic_typesupport_dynamic_data_t * dynamic_message,
+  bool * taken,
+  rmw_subscription_allocation_t * allocation)
+{
+  static_cast<void>(subscription);
+  static_cast<void>(dynamic_message);
+  static_cast<void>(taken);
+  static_cast<void>(allocation);
+
+  RMW_SET_ERROR_MSG("rmw_take_dynamic_message: unimplemented");
+  return RMW_RET_UNSUPPORTED;
+}
+
+rmw_ret_t
+rmw_take_dynamic_message_with_info(
+  const rmw_subscription_t * subscription,
+  rosidl_dynamic_typesupport_dynamic_data_t * dynamic_message,
+  bool * taken,
+  rmw_message_info_t * message_info,
+  rmw_subscription_allocation_t * allocation)
+{
+  static_cast<void>(subscription);
+  static_cast<void>(dynamic_message);
+  static_cast<void>(taken);
+  static_cast<void>(message_info);
+  static_cast<void>(allocation);
+
+  RMW_SET_ERROR_MSG("rmw_take_dynamic_message_with_info: unimplemented");
+  return RMW_RET_UNSUPPORTED;
+}
+
+rmw_ret_t
+rmw_get_serialization_support(
+  const char * serialization_lib_name,
+  rosidl_dynamic_typesupport_serialization_support_t ** serialization_support)
+{
+  static_cast<void>(serialization_lib_name);
+  static_cast<void>(serialization_support);
+
+  RMW_SET_ERROR_MSG("rmw_get_serialization_support: unimplemented");
+  return RMW_RET_UNSUPPORTED;
+}


### PR DESCRIPTION
This PR is part of the runtime interface reflection subscription feature of REP-2011: https://github.com/ros2/ros2/issues/1374

# Description
The PRs for REP-2011 introduced new rmw interfaces. rmw_connextdds will not support dynamic subscription yet, but must have the rmw interfaces implemented, so this PR adds stub implementations.