### PR TITLE
Use get_type_hash_func on typesupports (rep2011)

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/type_support.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/type_support.hpp
@@ -86,7 +86,7 @@ public:
 
   const rosidl_type_hash_t & type_hash() const
   {
-    return *_type_support_fastrtps->type_hash;
+    return *_type_support_fastrtps->get_type_hash_func(_type_support_fastrtps);
   }
 
   uint32_t type_serialized_size_max() const


### PR DESCRIPTION
Part of ros2/ros2#1159
Depends on ros2/rosidl#727 (and is bundled with)