### PR TITLE
Add ros2_tracing tracepoints

### DIFF
--- a/rmw_connextdds_common/CMakeLists.txt
+++ b/rmw_connextdds_common/CMakeLists.txt
@@ -112,6 +112,7 @@ set(RMW_CONNEXT_DEPS
     rcpputils
     rmw
     rmw_dds_common
+    tracetools
     fastcdr
     rosidl_runtime_c
     rosidl_runtime_cpp
@@ -128,6 +129,7 @@ endforeach()
 ################################################################################
 # Common Source Configuration
 ################################################################################
+
 set(RMW_CONNEXT_DIR     ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(RMW_CONNEXT_COMMON_SOURCE_CPP
@@ -171,6 +173,7 @@ set(RMW_CONNEXT_COMMON_SOURCE_HPP
 set(RMW_CONNEXT_COMMON_SOURCE
     ${RMW_CONNEXT_COMMON_SOURCE_CPP}
     ${RMW_CONNEXT_COMMON_SOURCE_HPP})
+
 
 ################################################################################
 # Check if additional Connext components are needed (e.g. security)

--- a/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
@@ -56,6 +56,11 @@ RMW_CONNEXTDDS_PUBLIC extern const char * const RMW_CONNEXTDDS_ID;
 extern const char * const RMW_CONNEXTDDS_SERIALIZATION_FORMAT;
 
 rmw_ret_t
+rmw_connextdds_get_current_time(
+  DDS_DomainParticipant * domain_participant,
+  struct DDS_Time_t * current_time);
+
+rmw_ret_t
 rmw_connextdds_set_log_verbosity(rmw_log_severity_t severity);
 
 rmw_ret_t

--- a/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
@@ -49,7 +49,7 @@ enum RMW_Connext_MessageType
 struct RMW_Connext_WriteParams
 {
   DDS_Time_t timestamp{DDS_TIME_INVALID};
-  int64_t * sn_out{nullptr};
+  int64_t sequence_number{0};
 };
 
 RMW_CONNEXTDDS_PUBLIC extern const char * const RMW_CONNEXTDDS_ID;

--- a/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
@@ -46,6 +46,12 @@ enum RMW_Connext_MessageType
   RMW_CONNEXT_MESSAGE_REPLY
 };
 
+struct RMW_Connext_WriteParams
+{
+  DDS_Time_t timestamp{DDS_TIME_INVALID};
+  int64_t * sn_out{nullptr};
+};
+
 RMW_CONNEXTDDS_PUBLIC extern const char * const RMW_CONNEXTDDS_ID;
 extern const char * const RMW_CONNEXTDDS_SERIALIZATION_FORMAT;
 
@@ -132,7 +138,7 @@ rmw_ret_t
 rmw_connextdds_write_message(
   RMW_Connext_Publisher * const pub,
   RMW_Connext_Message * const message,
-  int64_t * const sn_out);
+  RMW_Connext_WriteParams * const params = nullptr);
 
 rmw_ret_t
 rmw_connextdds_take_samples(

--- a/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
@@ -35,6 +35,9 @@
  * General helpers and utilities.
  ******************************************************************************/
 
+#define dds_time_to_u64(t_) \
+  ((1000000000ULL * (uint64_t)(t_)->sec) + (uint64_t)(t_)->nanosec)
+
 rcutils_ret_t
 rcutils_uint8_array_copy(
   rcutils_uint8_array_t * const dst,

--- a/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/rmw_impl.hpp
@@ -151,7 +151,7 @@ public:
   write(
     const void * const ros_message,
     const bool serialized,
-    int64_t * const sn_out = nullptr);
+    RMW_Connext_WriteParams * const params);
 
   rmw_ret_t
   enable() const

--- a/rmw_connextdds_common/package.xml
+++ b/rmw_connextdds_common/package.xml
@@ -22,6 +22,7 @@
   <depend>rosidl_typesupport_fastrtps_cpp</depend>
   <depend>rosidl_typesupport_introspection_c</depend>
   <depend>rosidl_typesupport_introspection_cpp</depend>
+  <depend>tracetools</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -1966,12 +1966,6 @@ rmw_connextdds_destroy_subscriber(
   return RMW_RET_OK;
 }
 
-static
-constexpr uint64_t C_NANOSECONDS_PER_SEC = 1000000000ULL;
-
-#define dds_time_to_u64(t_) \
-  ((C_NANOSECONDS_PER_SEC * (uint64_t)(t_)->sec) + (uint64_t)(t_)->nanosec)
-
 void
 rmw_connextdds_message_info_from_dds(
   rmw_message_info_t * const to,
@@ -2733,11 +2727,11 @@ RMW_Connext_Client::send_request(
   RMW_Connext_WriteParams write_params;
 
   if (DDS_RETCODE_OK !=
-    DDS_DomainParticipant_get_current_time(
+    rmw_connextdds_get_current_time(
       this->request_pub->dds_participant(),
       &write_params.timestamp))
   {
-    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
+    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time")
     return RMW_RET_ERROR;
   }
 
@@ -3021,11 +3015,11 @@ RMW_Connext_Service::send_response(
   RMW_Connext_WriteParams write_params;
 
   if (DDS_RETCODE_OK !=
-    DDS_DomainParticipant_get_current_time(
+    rmw_connextdds_get_current_time(
       this->reply_pub->dds_participant(),
       &write_params.timestamp))
   {
-    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
+    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time")
     return RMW_RET_ERROR;
   }
 

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -21,6 +21,8 @@
 
 #include "rcpputils/scope_exit.hpp"
 
+#include "tracetools/tracetools.h"
+
 #include "rmw_dds_common/time_utils.hpp"
 #include "rmw_dds_common/qos.hpp"
 
@@ -919,7 +921,7 @@ rmw_ret_t
 RMW_Connext_Publisher::write(
   const void * const ros_message,
   const bool serialized,
-  int64_t * const sn_out)
+  RMW_Connext_WriteParams * const params)
 {
   RMW_Connext_Message user_msg;
   if (RMW_RET_OK != RMW_Connext_Message_initialize(&user_msg, this->type_support, 0)) {
@@ -928,7 +930,7 @@ RMW_Connext_Publisher::write(
   user_msg.user_data = ros_message;
   user_msg.serialized = serialized;
 
-  return rmw_connextdds_write_message(this, &user_msg, sn_out);
+  return rmw_connextdds_write_message(this, &user_msg, params);
 }
 
 
@@ -1108,6 +1110,10 @@ rmw_connextdds_create_publisher(
     }
   }
 
+  TRACEPOINT(
+    rmw_publisher_init,
+    static_cast<const void *>(rmw_publisher),
+    rmw_pub_impl->gid()->data);
 
   scope_exit_rmw_writer_impl_delete.cancel();
   scope_exit_rmw_writer_delete.cancel();
@@ -1393,6 +1399,7 @@ RMW_Connext_Subscriber::create(
     RMW_CONNEXT_LOG_ERROR_SET("failed to allocate RMW subscriber")
     return nullptr;
   }
+
   scope_exit_dds_reader_delete.cancel();
   scope_exit_topic_delete.cancel();
   scope_exit_type_unregister.cancel();
@@ -1923,6 +1930,11 @@ rmw_connextdds_create_subscriber(
       return nullptr;
     }
   }
+
+  TRACEPOINT(
+    rmw_subscription_init,
+    static_cast<const void *>(rmw_subscriber),
+    rmw_sub_impl->gid()->data);
 
 #if RMW_CONNEXT_DEBUG && RMW_CONNEXT_DDS_API == RMW_CONNEXT_DDS_API_PRO
   scope_exit_enable_participant_on_error.cancel();
@@ -2723,7 +2735,20 @@ RMW_Connext_Client::send_request(
     reinterpret_cast<const uint32_t *>(rr_msg.gid.data)[3],
     rr_msg.sn)
 
-  rmw_ret_t rc = this->request_pub->write(&rr_msg, false /* serialized */, sequence_id);
+
+  RMW_Connext_WriteParams write_params;
+  write_params.sn_out = sequence_id;
+
+  if (DDS_RETCODE_OK !=
+    DDS_DomainParticipant_get_current_time(
+      this->request_pub->dds_participant(),
+      &write_params.timestamp))
+  {
+    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
+    return RMW_RET_ERROR;
+  }
+
+  rmw_ret_t rc = this->request_pub->write(&rr_msg, false /* serialized */, &write_params);
 
   RMW_CONNEXT_LOG_DEBUG_A(
     "[%s] SENT REQUEST: "
@@ -2998,6 +3023,17 @@ RMW_Connext_Service::send_response(
   rr_msg.gid.implementation_identifier = RMW_CONNEXTDDS_ID;
   rr_msg.payload = const_cast<void *>(ros_response);
 
+  RMW_Connext_WriteParams write_params;
+
+  if (DDS_RETCODE_OK !=
+    DDS_DomainParticipant_get_current_time(
+      this->request_pub->dds_participant(),
+      &write_params.timestamp))
+  {
+    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
+    return RMW_RET_ERROR;
+  }
+
   RMW_CONNEXT_LOG_DEBUG_A(
     "[%s] send RESPONSE: "
     "gid=%08X.%08X.%08X.%08X, "
@@ -3009,7 +3045,7 @@ RMW_Connext_Service::send_response(
     reinterpret_cast<const uint32_t *>(rr_msg.gid.data)[3],
     rr_msg.sn)
 
-  return this->reply_pub->write(&rr_msg, false /* serialized */);
+  return this->reply_pub->write(&rr_msg, false /* serialized */, write_params);
 }
 
 rmw_ret_t

--- a/rmw_connextdds_common/src/common/rmw_publication.cpp
+++ b/rmw_connextdds_common/src/common/rmw_publication.cpp
@@ -60,14 +60,15 @@ rmw_api_connextdds_publish(
 
   if (DDS_RETCODE_OK !=
     DDS_DomainParticipant_get_current_time(
-      this->request_pub->dds_participant(),
+      pub_impl->dds_participant(),
       &write_params.timestamp))
   {
     RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
     return RMW_RET_ERROR;
   }
 
-  TRACEPOINT(rmw_publish, publisher, ros_message, dds_time_to_u64(&write_params.timestamp));
+  TRACETOOLS_TRACEPOINT(
+    rmw_publish, publisher, ros_message, dds_time_to_u64(&write_params.timestamp));
 
   return pub_impl->write(ros_message, false /* serialized */, &write_params);
 }
@@ -100,14 +101,15 @@ rmw_api_connextdds_publish_serialized_message(
 
   if (DDS_RETCODE_OK !=
     DDS_DomainParticipant_get_current_time(
-      this->request_pub->dds_participant(),
+      pub_impl->dds_participant(),
       &write_params.timestamp))
   {
     RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
     return RMW_RET_ERROR;
   }
 
-  TRACEPOINT(rmw_publish, publisher, serialized_message, dds_time_to_u64(&write_params.timestamp));
+  TRACETOOLS_TRACEPOINT(
+    rmw_publish, publisher, serialized_message, dds_time_to_u64(&write_params.timestamp));
   return pub_impl->write(serialized_message, true /* serialized */, &write_params);
 }
 

--- a/rmw_connextdds_common/src/common/rmw_publication.cpp
+++ b/rmw_connextdds_common/src/common/rmw_publication.cpp
@@ -19,6 +19,15 @@
 
 #include "rmw/validate_full_topic_name.h"
 
+#include "tracetools/tracetools.h"
+
+static
+constexpr uint64_t C_NANOSECONDS_PER_SEC = 1000000000ULL;
+
+#define dds_time_to_u64(t_) \
+  ((C_NANOSECONDS_PER_SEC * (uint64_t)(t_)->sec) + (uint64_t)(t_)->nanosec)
+
+
 /******************************************************************************
  * Publication functions
  ******************************************************************************/
@@ -47,7 +56,20 @@ rmw_api_connextdds_publish(
   auto pub_impl = static_cast<RMW_Connext_Publisher *>(publisher->data);
   RMW_CHECK_ARGUMENT_FOR_NULL(pub_impl, RMW_RET_INVALID_ARGUMENT);
 
-  return pub_impl->write(ros_message, false /* serialized */);
+  RMW_Connext_WriteParams write_params;
+
+  if (DDS_RETCODE_OK !=
+    DDS_DomainParticipant_get_current_time(
+      this->request_pub->dds_participant(),
+      &write_params.timestamp))
+  {
+    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
+    return RMW_RET_ERROR;
+  }
+
+  TRACEPOINT(rmw_publish, publisher, ros_message, dds_time_to_u64(&write_params.timestamp));
+
+  return pub_impl->write(ros_message, false /* serialized */, &write_params);
 }
 
 
@@ -74,7 +96,19 @@ rmw_api_connextdds_publish_serialized_message(
   auto pub_impl = static_cast<RMW_Connext_Publisher *>(publisher->data);
   RMW_CHECK_ARGUMENT_FOR_NULL(pub_impl, RMW_RET_INVALID_ARGUMENT);
 
-  return pub_impl->write(serialized_message, true /* serialized */);
+  RMW_Connext_WriteParams write_params;
+
+  if (DDS_RETCODE_OK !=
+    DDS_DomainParticipant_get_current_time(
+      this->request_pub->dds_participant(),
+      &write_params.timestamp))
+  {
+    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
+    return RMW_RET_ERROR;
+  }
+
+  TRACEPOINT(rmw_publish, publisher, serialized_message, dds_time_to_u64(&write_params.timestamp));
+  return pub_impl->write(serialized_message, true /* serialized */, &write_params);
 }
 
 

--- a/rmw_connextdds_common/src/common/rmw_publication.cpp
+++ b/rmw_connextdds_common/src/common/rmw_publication.cpp
@@ -21,13 +21,6 @@
 
 #include "tracetools/tracetools.h"
 
-static
-constexpr uint64_t C_NANOSECONDS_PER_SEC = 1000000000ULL;
-
-#define dds_time_to_u64(t_) \
-  ((C_NANOSECONDS_PER_SEC * (uint64_t)(t_)->sec) + (uint64_t)(t_)->nanosec)
-
-
 /******************************************************************************
  * Publication functions
  ******************************************************************************/
@@ -59,11 +52,11 @@ rmw_api_connextdds_publish(
   RMW_Connext_WriteParams write_params;
 
   if (DDS_RETCODE_OK !=
-    DDS_DomainParticipant_get_current_time(
+    rmw_connextdds_get_current_time(
       pub_impl->dds_participant(),
       &write_params.timestamp))
   {
-    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
+    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time")
     return RMW_RET_ERROR;
   }
 
@@ -100,11 +93,11 @@ rmw_api_connextdds_publish_serialized_message(
   RMW_Connext_WriteParams write_params;
 
   if (DDS_RETCODE_OK !=
-    DDS_DomainParticipant_get_current_time(
+    rmw_connextdds_get_current_time(
       pub_impl->dds_participant(),
       &write_params.timestamp))
   {
-    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time from DDS Domain Participant")
+    RMW_CONNEXT_LOG_ERROR_SET("failed to get current time")
     return RMW_RET_ERROR;
   }
 

--- a/rmw_connextdds_common/src/common/rmw_subscription.cpp
+++ b/rmw_connextdds_common/src/common/rmw_subscription.cpp
@@ -19,6 +19,8 @@
 
 #include "rmw/validate_full_topic_name.h"
 
+#include "tracetools/tracetools.h"
+
 /******************************************************************************
  * Subscription functions
  ******************************************************************************/
@@ -282,6 +284,12 @@ rmw_api_connextdds_take(
 
   rmw_ret_t rc = sub_impl->take_message(ros_message, nullptr, taken);
 
+  TRACEPOINT(
+    rmw_take,
+    static_cast<const void *>(subscription),
+    static_cast<const void *>(ros_message),
+    0LL,
+    *taken);
   return rc;
 }
 
@@ -310,6 +318,13 @@ rmw_api_connextdds_take_with_info(
     reinterpret_cast<RMW_Connext_Subscriber *>(subscription->data);
 
   rmw_ret_t rc = sub_impl->take_message(ros_message, message_info, taken);
+
+  TRACEPOINT(
+    rmw_take,
+    static_cast<const void *>(subscription),
+    static_cast<const void *>(ros_message),
+    (message_info ? message_info->source_timestamp : 0LL),
+    *taken);
 
   return rc;
 }

--- a/rmw_connextdds_common/src/common/rmw_subscription.cpp
+++ b/rmw_connextdds_common/src/common/rmw_subscription.cpp
@@ -284,12 +284,7 @@ rmw_api_connextdds_take(
 
   rmw_ret_t rc = sub_impl->take_message(ros_message, nullptr, taken);
 
-  TRACEPOINT(
-    rmw_take,
-    static_cast<const void *>(subscription),
-    static_cast<const void *>(ros_message),
-    0LL,
-    *taken);
+  TRACETOOLS_TRACEPOINT(rmw_take, subscription, ros_message, 0LL, *taken);
   return rc;
 }
 
@@ -319,10 +314,10 @@ rmw_api_connextdds_take_with_info(
 
   rmw_ret_t rc = sub_impl->take_message(ros_message, message_info, taken);
 
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rmw_take,
-    static_cast<const void *>(subscription),
-    static_cast<const void *>(ros_message),
+    subscription,
+    ros_message,
     (message_info ? message_info->source_timestamp : 0LL),
     *taken);
 

--- a/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
+++ b/rmw_connextdds_common/src/ndds/dds_api_ndds.cpp
@@ -37,6 +37,22 @@ struct rmw_connextdds_api_pro
 rmw_connextdds_api_pro * RMW_Connext_fv_FactoryContext = nullptr;
 
 rmw_ret_t
+rmw_connextdds_get_current_time(
+  DDS_DomainParticipant * domain_participant,
+  struct DDS_Time_t * current_time)
+{
+  // Use DDS_DomainParticipant_get_current_time only with Micro since Pro's
+  // implementation is pretty slow. See #120 for details.
+  UNUSED_ARG(domain_participant);
+  RTINtpTime now;
+  if (!RTIOsapiUtility_getTime(&now)) {
+    return DDS_RETCODE_ERROR;
+  }
+  RTINtpTime_unpackToNanosec(current_time->sec, current_time->nanosec, now);
+  return DDS_RETCODE_OK;
+}
+
+rmw_ret_t
 rmw_connextdds_set_log_verbosity(rmw_log_severity_t severity)
 {
   NDDS_Config_Logger * logger = NDDS_Config_Logger_get_instance();

--- a/rmw_connextdds_common/src/rtime/dds_api_rtime.cpp
+++ b/rmw_connextdds_common/src/rtime/dds_api_rtime.cpp
@@ -378,6 +378,16 @@ struct rmw_connextdds_api_micro
 
 rmw_connextdds_api_micro * RMW_Connext_fv_FactoryContext = nullptr;
 
+rmw_ret_t
+rmw_connextdds_get_current_time(
+  DDS_DomainParticipant * domain_participant,
+  struct DDS_Time_t * current_time)
+{
+  // Use DDS_DomainParticipant_get_current_time only with Micro since Pro's
+  // implementation is pretty slow. See #120 for details.
+  return DDS_DomainParticipant_get_current_time(domain_participant, current_time);
+}
+
 const char * const RMW_CONNEXTDDS_ID = "rmw_connextddsmicro";
 const char * const RMW_CONNEXTDDS_SERIALIZATION_FORMAT = "cdr";
 

--- a/rmw_connextdds_common/src/rtime/dds_api_rtime.cpp
+++ b/rmw_connextdds_common/src/rtime/dds_api_rtime.cpp
@@ -1153,12 +1153,11 @@ rmw_ret_t
 rmw_connextdds_write_message(
   RMW_Connext_Publisher * const pub,
   RMW_Connext_Message * const message,
-  int64_t * const sn_out)
+  RMW_Connext_WriteParams * const params)
 {
-  UNUSED_ARG(sn_out);
-
+  DDS_Time_t timestamp = (params != nullptr) ? params->timestamp : DDS_TIME_INVALID;
   if (DDS_RETCODE_OK !=
-    DDS_DataWriter_write(pub->writer(), message, &DDS_HANDLE_NIL))
+    DDS_DataWriter_write_w_timestamp(pub->writer(), message, &DDS_HANDLE_NIL, &timestamp))
   {
     RMW_CONNEXT_LOG_ERROR_SET("failed to write message to DDS")
     return RMW_RET_ERROR;

--- a/rmw_connextdds_common/src/rtime/dds_api_rtime.cpp
+++ b/rmw_connextdds_common/src/rtime/dds_api_rtime.cpp
@@ -1155,7 +1155,10 @@ rmw_connextdds_write_message(
   RMW_Connext_Message * const message,
   RMW_Connext_WriteParams * const params)
 {
-  DDS_Time_t timestamp = (params != nullptr) ? params->timestamp : DDS_TIME_INVALID;
+  DDS_Time_t timestamp = DDS_TIME_INVALID;
+  if (nullptr != params && !DDS_Time_is_invalid(&params->timestamp)) {
+    timestamp = params->timestamp;
+  }
   if (DDS_RETCODE_OK !=
     DDS_DataWriter_write_w_timestamp(pub->writer(), message, &DDS_HANDLE_NIL, &timestamp))
   {


### PR DESCRIPTION
Depends on https://github.com/ros2/ros2_tracing/pull/74; implements: https://github.com/ros2/ros2_tracing/issues/73

This PR introduces ros2_tracing tracepoints which are really helpful for examining system performance. The dependency to the ros2_tracing PR stems from the fact, that one of the original tracepoints had to be extended in order to get the timestamp during writing to DDS.

In order to do that, `DDS_DataWriter_write_untypedI` had to be replaced with  `DDS_DataWriter_write_w_timestamp_untypedI`. At first it seemed reasonable to use` in order to get the respective timestamp.

This seems to work, but `DDS_DomainParticipant_get_current_time` introduces a massive performance penality. The flamegraph below shows the result of profiling it using perf.
![grafik](https://github.com/ros2/rmw_connextdds/assets/20225760/93a18683-7649-42e8-b028-8bce90eac7c3)

From https://community.rti.com/kb/how-clocks-are-used-connext-dds I'd conclude, that we need the "external clock" used by Connext here. Looking at the perf profile, it seems that there is a method/function `DDS_DomainParticipant_get_external_clockI` which would provide to us said clock, but it seems that this function is not part of Connexts public API right? Is there any way to get this clock or the timestamp which Connext would use if  `DDS_DataWriter_write_untypedI` is used without paying such a massive performance penalty?