### PR TITLE
Clear out errors once we have handled them.

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_graph.cpp
+++ b/rmw_connextdds_common/src/common/rmw_graph.cpp
@@ -1001,6 +1001,8 @@ rmw_connextdds_graph_add_remote_entity(
       topic_name, type_name,
       static_cast<int>(user_data_size), reinterpret_cast<const char *>(user_data_data));
     type_hash = rosidl_get_zero_initialized_type_hash();
+    // We handled the error, so clear it out
+    rmw_reset_error();
   }
 
   rmw_ret_t rc = rmw_connextdds_graph_add_entityEA(

--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -462,6 +462,8 @@ rmw_connextdds_get_readerwriter_qos(
     RMW_CONNEXT_LOG_WARNING(
       "Failed to encode type hash for topic, will not distribute it in USER_DATA.");
     user_data_str.clear();
+    // We handled the error, so clear it out
+    rmw_reset_error();
   }
   DDS_OctetSeq_from_array(
     &user_data->value,


### PR DESCRIPTION
In particular, in the type-hash code we can handle a failure to encode or parse the type hash from the user data. Once we've handled it, and printed out an error about it, we should clear it because we are going to continue on and something else down the line might have an error.

This will avoid errors like:

This error state is being overwritten:

with this new error message: