### PR TITLE
Fix a couple of warnings pointed out by clang.

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/context.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/context.hpp
@@ -176,8 +176,6 @@ private:
   rmw_ret_t
   finalize_participant();
 
-  DDS_DomainParticipantFactory * factory{nullptr};
-
   /* Manage the memory of the domain tag */
   char * domain_tag{nullptr};
 

--- a/rmw_connextdds_common/src/common/rmw_context.cpp
+++ b/rmw_connextdds_common/src/common/rmw_context.cpp
@@ -301,8 +301,8 @@ rmw_context_impl_s::initialize_discovery_options(DDS_DomainParticipantQos & dp_q
       // If it's too large then we will send a lot of announcement traffic.
       // The default number here is picked arbitrarily.
       const rmw_peer_address_t localhost_peers[2] = {
-        "32@builtin.udpv4://127.0.0.1",
-        "32@builtin.shmem://",
+        {"32@builtin.udpv4://127.0.0.1"},
+        {"32@builtin.shmem://"},
       };
       const auto rc2 = rmw_connextdds_extend_initial_peer_list(
         localhost_peers,


### PR DESCRIPTION
1.  Add braces around initialization of array elements.
2.  Remove an unused structure member.