### PR TITLE
prevent setting CONNEXTDDS_ARCH when a more proper one exists

### DIFF
--- a/rti_connext_dds_cmake_module/cmake/rti_build_helper.cmake
+++ b/rti_connext_dds_cmake_module/cmake/rti_build_helper.cmake
@@ -476,6 +476,7 @@ function(rti_guess_connextdds_arch)
     message(STATUS
       "Pick first from ${CONNEXTDDS_DIR}/lib/[${architectures_installed}]")
 
+    set(architecture_candidates "")
     foreach(architecture_name ${architectures_installed})
       # Because the lib folder contains both target libraries and
       # Java JAR files, here we exclude the "java" in our algorithm
@@ -516,11 +517,7 @@ function(rti_guess_connextdds_arch)
           endif()
         endif()
         if(NOT CONNEXTDDS_ARCH)
-          message(STATUS
-            "unsupported CMAKE_HOST_SYSTEM_NAME (${CMAKE_HOST_SYSTEM_NAME}) "
-            "or CMAKE_HOST_SYSTEM_PROCESSOR (${CMAKE_HOST_SYSTEM_PROCESSOR}). "
-            "Using architecture ${architecture_name} anyway.")
-          set(CONNEXTDDS_ARCH "${architecture_name}")
+          list(APPEND architecture_candidates ${architecture_name})
         endif()
       else()
         message(STATUS "ignored foreign architecture: ${architecture_name}")
@@ -529,18 +526,25 @@ function(rti_guess_connextdds_arch)
       if(CONNEXTDDS_ARCH)
         break()
       endif()
+
     endforeach()
-  endif()
 
-  if(NOT CONNEXTDDS_ARCH)
-    message(WARNING
-      "CONNEXTDDS_ARCH not specified. Please set "
-      "-DCONNEXTDDS_ARCH= to specify your RTI Connext DDS "
-      " architecture")
-  else()
-      message(STATUS "Selected CONNEXTDDS_ARCH: ${CONNEXTDDS_ARCH}")
-  endif()
+    if(NOT CONNEXTDDS_ARCH)
+      list(GET architecture_candidates 0 CONNEXTDDS_ARCH)
+      if(CONNEXTDDS_ARCH)
+        message(STATUS
+          "unsupported CMAKE_HOST_SYSTEM_NAME (${CMAKE_HOST_SYSTEM_NAME}) "
+          "or CMAKE_HOST_SYSTEM_PROCESSOR (${CMAKE_HOST_SYSTEM_PROCESSOR}). "
+          "Using architecture ${CONNEXTDDS_ARCH} anyway.")
+      else()
+        message(WARNING
+          "CONNEXTDDS_ARCH not specified. Please set "
+          "-DCONNEXTDDS_ARCH= to specify your RTI Connext DDS "
+          " architecture")
+      endif()
+    endif()
 
+  endif()
 
   set(CONNEXTDDS_ARCH "${CONNEXTDDS_ARCH}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
The original line 519-523 may result in an improper architect is selected while a proper one can exist.

For example, if you have 
**CMAKE_HOST_SYSTEM_NAME=Linux
CMAKE_HOST_SYSTEM_PROCESSOR=x86_64
architectures_installed=[armv8Linux4.4gcc5.4.0;x64Linux4gcc7.3.0]**

the original cmake will set CONNEXTDDS_ARCH as **armv8Linux4.4gcc5.4.0** and break the foreach loop in the first entry without looking at the latter possible architects.

After the change,  **armv8Linux4.4gcc5.4.0** will be put into a _architecture_candidates_ list and continue searching, if **x64Linux4gcc7.3.0** can be found then it will select this one, if not it will select **armv8Linux4.4gcc5.4.0** as the best choice.