### PR TITLE
Fix basic request reply mapping for ConnextDDS Pro

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_impl.cpp
+++ b/rmw_connextdds_common/src/common/rmw_impl.cpp
@@ -2723,7 +2723,6 @@ RMW_Connext_Client::send_request(
     reinterpret_cast<const uint32_t *>(rr_msg.gid.data)[3],
     rr_msg.sn)
 
-
   RMW_Connext_WriteParams write_params;
 
   if (DDS_RETCODE_OK !=
@@ -2737,7 +2736,9 @@ RMW_Connext_Client::send_request(
 
   rmw_ret_t rc = this->request_pub->write(&rr_msg, false /* serialized */, &write_params);
 
-  *sequence_id = write_params.sequence_number;
+  if (this->ctx->request_reply_mapping != RMW_Connext_RequestReplyMapping::Basic) {
+    *sequence_id = write_params.sequence_number;
+  }
 
   RMW_CONNEXT_LOG_DEBUG_A(
     "[%s] SENT REQUEST: "

--- a/rmw_connextdds_common/src/common/rmw_type_support.cpp
+++ b/rmw_connextdds_common/src/common/rmw_type_support.cpp
@@ -98,10 +98,7 @@ RMW_Connext_RequestReplyMapping_Basic_serialize(
   if (RMW_RET_OK != rc) {
     return rc;
   }
-  sample_identity.sequence_number.high =
-    static_cast<DDS_Long>((rr_msg->sn & 0xFFFFFFFF00000000) >> 8);
-  sample_identity.sequence_number.low =
-    static_cast<DDS_UnsignedLong>(rr_msg->sn & 0x00000000FFFFFFFF);
+  rmw_connextdds_sn_ros_to_dds(rr_msg->sn, sample_identity.sequence_number);
 
   try {
     // Cyclone only serializes 8 bytes of the writer guid.


### PR DESCRIPTION
There are two fixes:

1. one conversion from int64 to SequenceNumber_t was wrong.
2. If basic request reply mapping is used with ConnextDDS Pro (e.g. in order to interact with ConnextDDS Micro), the old version overwrites the sequence number passed out to RCL. This makes it impossible for the client libraries to associate any response with its corresponding request.