### PR TITLE
Add DDS_TIME_INVALID and DDS_Time_is_invalid for connext micro

### DIFF
--- a/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/dds_api.hpp
@@ -48,8 +48,8 @@ enum RMW_Connext_MessageType
 
 struct RMW_Connext_WriteParams
 {
-  DDS_Time_t timestamp{DDS_TIME_INVALID};
-  int64_t sequence_number{0};
+  DDS_Time_t timestamp = DDS_TIME_INVALID;
+  int64_t sequence_number = 0L;
 };
 
 RMW_CONNEXTDDS_PUBLIC extern const char * const RMW_CONNEXTDDS_ID;

--- a/rmw_connextdds_common/include/rmw_connextdds/dds_api_rtime.hpp
+++ b/rmw_connextdds_common/include/rmw_connextdds/dds_api_rtime.hpp
@@ -73,4 +73,9 @@ struct DDS_LifespanQosPolicy;
 // Not available function
 #define DDS_DataWriter_wait_for_acknowledgments(writer_, timeout_)    DDS_RETCODE_UNSUPPORTED
 
+#define DDS_Time_is_invalid(timePtr) \
+  ((timePtr)->sec < 0)
+
+#define DDS_TIME_INVALID {-1L, 0UL}
+
 #endif  // RMW_CONNEXTDDS__DDS_API_RTIME_HPP_


### PR DESCRIPTION
For whatever reasons ConnextDDS micro exports DDS_TIME_INVALID but it doesn't define it. Therefore this results in a runtime error - because during runtime as the shared library is loaded, the symbol to DDS_TIME_INVALID can not be resolved.

Also DDS_Time_is_invalid is not defined. So both need to be added in order to make rmw_connextmicro work.