### PR TITLE
Fixed naming convention of service response topics in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ ROS mangles topic names in the following way:
 
 - Topics are prefixed with `rt`. e.g.: `/my/fully/qualified/ros/topic` is converted to `rt/my/fully/qualified/ros/topic`.
 - The service request topics are prefixed with `rq` and suffixed with `Request`. e.g.: `/my/fully/qualified/ros/service` request topic is `rq/my/fully/qualified/ros/serviceRequest`.
-- The service response topics are prefixed with `rr` and suffixed with `Response`. e.g.: `/my/fully/qualified/ros/service` response topic is `rr/my/fully/qualified/ros/serviceResponse`.
+- The service response topics are prefixed with `rr` and suffixed with `Reply`. e.g.: `/my/fully/qualified/ros/service` response topic is `rr/my/fully/qualified/ros/serviceReply`.
 
 ### RMW_CONNEXT_INITIAL_PEERS
 


### PR DESCRIPTION
The documentation of the topic naming convention for service responses has been wrong. In fact the suffix is not "Response" but "Reply":

- https://github.com/ros2/rmw_connextdds/blob/eebc271fa1420d1b9135a56f4507fe134460f39d/rmw_connextdds_common/src/common/rmw_info.cpp#L328
- https://github.com/ros2/rmw_cyclonedds/blob/d8973e818db1546975478dc59699f78417b9051b/rmw_cyclonedds_cpp/src/rmw_node.cpp#L4948