### PR TITLE
Add: tracepoint for subscribe serialized_message

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_subscription.cpp
+++ b/rmw_connextdds_common/src/common/rmw_subscription.cpp
@@ -386,6 +386,8 @@ rmw_api_connextdds_take_serialized_message(
   RMW_Connext_Subscriber * const sub_impl =
     reinterpret_cast<RMW_Connext_Subscriber *>(subscription->data);
 
+  rmw_ret_t rc = sub_impl->take_serialized(serialized_message, nullptr, taken);
+
   TRACETOOLS_TRACEPOINT(
     rmw_take,
     subscription,
@@ -393,7 +395,7 @@ rmw_api_connextdds_take_serialized_message(
     0LL,
     *taken);
 
-  return sub_impl->take_serialized(serialized_message, nullptr, taken);
+  return rc;
 }
 
 

--- a/rmw_connextdds_common/src/common/rmw_subscription.cpp
+++ b/rmw_connextdds_common/src/common/rmw_subscription.cpp
@@ -386,6 +386,13 @@ rmw_api_connextdds_take_serialized_message(
   RMW_Connext_Subscriber * const sub_impl =
     reinterpret_cast<RMW_Connext_Subscriber *>(subscription->data);
 
+  TRACETOOLS_TRACEPOINT(
+    rmw_take,
+    subscription,
+    serialized_message,
+    (message_info ? message_info->source_timestamp : 0LL),
+    *taken);
+
   return sub_impl->take_serialized(serialized_message, nullptr, taken);
 }
 
@@ -412,6 +419,13 @@ rmw_api_connextdds_take_serialized_message_with_info(
 
   RMW_Connext_Subscriber * const sub_impl =
     reinterpret_cast<RMW_Connext_Subscriber *>(subscription->data);
+
+  TRACETOOLS_TRACEPOINT(
+    rmw_take,
+    subscription,
+    serialized_message,
+    (message_info ? message_info->source_timestamp : 0LL),
+    *taken);
 
   return sub_impl->take_serialized(serialized_message, message_info, taken);
 }

--- a/rmw_connextdds_common/src/common/rmw_subscription.cpp
+++ b/rmw_connextdds_common/src/common/rmw_subscription.cpp
@@ -390,7 +390,7 @@ rmw_api_connextdds_take_serialized_message(
     rmw_take,
     subscription,
     serialized_message,
-    (message_info ? message_info->source_timestamp : 0LL),
+    0LL,
     *taken);
 
   return sub_impl->take_serialized(serialized_message, nullptr, taken);
@@ -424,7 +424,7 @@ rmw_api_connextdds_take_serialized_message_with_info(
     rmw_take,
     subscription,
     serialized_message,
-    (message_info ? message_info->source_timestamp : 0LL),
+    message_info->source_timestamp,
     *taken);
 
   return sub_impl->take_serialized(serialized_message, message_info, taken);

--- a/rmw_connextdds_common/src/common/rmw_subscription.cpp
+++ b/rmw_connextdds_common/src/common/rmw_subscription.cpp
@@ -422,14 +422,16 @@ rmw_api_connextdds_take_serialized_message_with_info(
   RMW_Connext_Subscriber * const sub_impl =
     reinterpret_cast<RMW_Connext_Subscriber *>(subscription->data);
 
+  rmw_ret_t rc = sub_impl->take_serialized(serialized_message, message_info, taken);
+
   TRACETOOLS_TRACEPOINT(
     rmw_take,
     subscription,
     serialized_message,
-    message_info->source_timestamp,
+    (message_info ? message_info->source_timestamp : 0LL),
     *taken);
 
-  return sub_impl->take_serialized(serialized_message, message_info, taken);
+  return rc;
 }
 
 


### PR DESCRIPTION
Please, refer to https://github.com/ros2/rclcpp/pull/2448 .
I have added the following trace points.

-  `rmw_api_connextdds_take_serialized_message()`
   - rmw_take
 - `rmw_api_connextdds_take_serialized_message_with_info()`
   - rmw_take