### PR TITLE
Make rmw_service_server_is_available return RMW_RET_INVALID_ARGUMENT

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_info.cpp
+++ b/rmw_connextdds_common/src/common/rmw_info.cpp
@@ -188,25 +188,19 @@ rmw_api_connextdds_service_server_is_available(
   const rmw_client_t * client,
   bool * is_available)
 {
-  // TODO(asorbini): Return RMW_RET_INVALID_ARGUMENT. We return RMW_RET_ERROR
-  // because that's what's expected by test_rmw_implementation
-  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_ERROR);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node,
     node->implementation_identifier,
     RMW_CONNEXTDDS_ID,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  // TODO(asorbini): Return RMW_RET_INVALID_ARGUMENT. We return RMW_RET_ERROR
-  // because that's what's expected by test_rmw_implementation
-  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_ERROR);
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     client,
     client->implementation_identifier,
     RMW_CONNEXTDDS_ID,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  // TODO(asorbini): Return RMW_RET_INVALID_ARGUMENT. We return RMW_RET_ERROR
-  // because that's what's expected by test_rmw_implementation
-  RMW_CHECK_ARGUMENT_FOR_NULL(is_available, RMW_RET_ERROR);
+  RMW_CHECK_ARGUMENT_FOR_NULL(is_available, RMW_RET_INVALID_ARGUMENT);
 
   RMW_Connext_Client * const client_impl =
     reinterpret_cast<RMW_Connext_Client *>(client->data);


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/277 changed the `rmw_service_server_is_available()` API documentation to indicate that it returns `RMW_RET_INVALID_ARGUMENT` if `node`, `client`, or `is_available` are `NULL`. However, this wasn't the case in practice in the implementations of `rmw_service_server_is_available()` or in the relevant test.

Change the implementation here to return `RMW_RET_INVALID_ARGUMENT`.

Requires https://github.com/ros2/rmw_implementation/pull/231