### PR TITLE
Make rmw_destroy_wait_set return RMW_RET_INVALID_ARGUMENT

### DIFF
--- a/rmw_connextdds_common/src/common/rmw_waitset.cpp
+++ b/rmw_connextdds_common/src/common/rmw_waitset.cpp
@@ -105,9 +105,7 @@ rmw_api_connextdds_create_wait_set(
 rmw_ret_t
 rmw_api_connextdds_destroy_wait_set(rmw_wait_set_t * rmw_ws)
 {
-  // TODO(asorbini): Return RMW_RET_INVALID_ARGUMENT. We return RMW_RET_ERROR
-  // because that's what's expected by test_rmw_implementation
-  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_ws, RMW_RET_ERROR);
+  RMW_CHECK_ARGUMENT_FOR_NULL(rmw_ws, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     rmw_ws,
     rmw_ws->implementation_identifier,


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/275 changed the `rmw_destroy_wait_set()` API documentation to indicate that it returns `RMW_RET_INVALID_ARGUMENT` if `wait_set` is `NULL`. However, this wasn't the case in practice in the implementations of `rmw_destroy_wait_set()` or in the relevant test.

Change the implementation here to return `RMW_RET_INVALID_ARGUMENT`.

Requires https://github.com/ros2/rmw_implementation/pull/234