### PR TITLE
Filter the non-commercial license notice out of test output

### DIFF
--- a/rmw_connextdds/CMakeLists.txt
+++ b/rmw_connextdds/CMakeLists.txt
@@ -108,5 +108,12 @@ ament_package(
   CONFIG_EXTRAS_POST "${PROJECT_NAME}-extras.cmake.in"
 )
 
+# Connext prints a licensing notice on stdout when it starts up under a
+# non-commercial license. These resources let launch_testing_ros filter it out,
+# so that tests matching process output exactly are not thrown off by it. The
+# blank line the notice ends with is filtered as a pattern, since it cannot be
+# expressed as a prefix.
 ament_index_register_resource("rmw_output_prefixes"
-  CONTENT "RTI Data Distribution Service\nRTI Connext DDS\nExpires on")
+  CONTENT "RTI Data Distribution Service\nRTI Connext DDS\nExpires on\n[RTI LICENSE]\nPlease contact support@rti.com")
+ament_index_register_resource("rmw_output_patterns"
+  CONTENT "^[ \t]*$")


### PR DESCRIPTION
## Description

When Connext starts up under a non-commercial license (the `rti-connext-dds-*-ros` debs, installed with `RTI_NC_LICENSE_ACCEPTED=yes`) it prints a licensing notice on stdout, once per participant:

```
[RTI LICENSE] | RTI Connext licensed for prototype, research and non-commercial use only. USE FOR OTHER COMMERCIAL PURPOSES IS PROHIBITED. See RTI_License_Agreement_LM file for terms. For free tools and additional capabilities register at https://rti.com/ros - License issued to Non-Commercial and Prototype User license@rti.com For non-production use only.
Please contact support@rti.com with any questions or comments.
<blank line>
```

The `rmw_output_prefixes` resource that `launch_testing_ros` uses to filter DDS chatter out of process output has not been touched since it was added in 312ef11 (2021), and still only covers the older banner (`RTI Data Distribution Service` / `RTI Connext DDS` / `Expires on`). None of the three lines above match, so they survive the filter.

The result is that any test asserting on exact process output fails on the licensing notice rather than on the output it is actually checking. `launch_testing.tools.expect_output(..., strict=True)` requires the first expected line to be at index 0, and index 0 is the notice.

This is the cause of https://github.com/ros2/ros2cli/issues/1129. In `nightly_linux-aarch64_release` #3680, `ros2 topic echo --csv /defaults` emits exactly the expected rows and the assertion still fails; 33 of `ros2topic`'s `test_cli` tests carry `@retry_on_failure(times=5, delay=1)` with 10 s waits, so the retries push the single `launch_testing` pytest item past the 900 s `pytest-timeout` and the run dies without writing JUnit XML — which is why it surfaces as `ros2topic.pytest.missing_result` with no detail. `ros2lifecycle` in the same build names it outright:

```
AssertionError: assert not '[RTI LICENSE] | RTI Connext licensed for prototype, research…\nPlease contact support@rti.com…\n\n'
```

It reproduces only where there is no license file. `nightly_linux_release` (x86) installs Connext from the RTI web installer and exports `RTI_LICENSE_FILE`, prints no notice, and passes; `nightly_linux-aarch64_release` and the `Rci`/`Kci` jobs on build.ros2.org use the non-commercial debs and fail. Both are on Connext 7.7.0, so this is not a version difference.

## Changes

* Add `[RTI LICENSE]` and `Please contact support@rti.com` to `rmw_output_prefixes`. The existing entries are kept, since older Connext versions still emit them.
* Register `rmw_output_patterns` with `^[ \t]*$` for the blank line the notice ends with. That line cannot be expressed as a prefix, and on its own it is enough to break a strict match. `rmw_cyclonedds_cpp` already registers a patterns resource the same way.

## Testing

Verified against the real implementation and the real input: the filter content CMake generates from this change, fed through `launch_testing.tools.basic_output_filter` and `expect_output(strict=True)`, against the stdout captured verbatim from `nightly_linux-aarch64_release` #3680 and `ros2topic`'s `test_csv_topic_echo` assertion.

```
before: strict match = False  first surviving line = [RTI LICENSE] | RTI Connext licensed for prototype, research and non-c
after : strict match = True   first surviving line = True,b'2',100,1.125,1.125,-50,200,-1000,2000,-30000,60000,-40000000,50
```

CI on a machine using the non-commercial license is the real test — this needs a `Rci__nightly-connext` style job to confirm.

## Is this user-facing behavior change?

No. Test-support metadata only; nothing in the RMW itself changes.

## Did you use Generative AI?

Yes. Claude Code [Opus 5] — investigation of the CI logs and the patch.
